### PR TITLE
Support deleting model properties during assignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,11 @@ Merge works identical to initialize, except that it mutates an existing instance
     var account = new Account({...});
     account.merge(data, { map: 'facebook' });
 
+Explicitly setting a property on an object to undefined will mark that property for deletion. For example,
+
+    var account = new Account({ ssn: '123-456-7890' });
+    account.merge({ ssn: undefined });
+
 
 #### Serialization and deserialization
 

--- a/lib/Modinha.js
+++ b/lib/Modinha.js
@@ -203,8 +203,6 @@ Modinha.prototype.initialize = function (data, options) {
  * Merge
  *
  * Invokes initialize but enforces non-assignment of defaults.
- * Need to consider how to delete keys and set to undefined, since
- * initialize doesn't assign undefined values.
  */
 
 Modinha.prototype.merge = function (data, options) {

--- a/lib/initialize.js
+++ b/lib/initialize.js
@@ -88,6 +88,11 @@ function assign (key, descriptor, source, target, options) {
       target[key] = value;
     }
 
+    // delete property if explicitly undefined
+    else if (source.hasOwnProperty(key) && value === undefined) {
+      delete target[key];
+    }
+
     // assign default value
     else if (descriptor.default && options.defaults !== false) {
       var defaultValue = descriptor.default;

--- a/test/InitializeSpec.coffee
+++ b/test/InitializeSpec.coffee
@@ -65,6 +65,8 @@ describe 'assign', ->
     descriptors =
       simple:    { type: 'string' }
       private:   { type: 'string', private: true }
+      deleted:   { type: 'string' }
+      exists:    { type: 'string' }
       immutable: { type: 'string', immutable: true }
       setter:    { type: 'string', set: (data) -> @setter = "#{data.setter}ter" }
       default:   { type: 'string', default: 'default' }
@@ -72,16 +74,28 @@ describe 'assign', ->
       after:     { type: 'string', after: (data) -> @setAfter = "#{data.after} assignment"}
     source =
       simple: 'simple'
+      deleted: undefined
       private: 'private'
       immutable: 'immutable'
       setter: 'set'
       after: 'after'
-    target = {}
+    target =
+      deleted: 'not deleted'
+      exists:  'exists'
     options = {}
 
   it 'should set a property on target from source', ->
     assign('simple', descriptors.simple, source, target, options)
     target.simple.should.equal 'simple'
+
+  it 'should remove target properties explicitly undefined on source', ->
+    assign('deleted', descriptors.deleted, source, target, options)
+    target.should.not.have.property('deleted')
+
+  it 'should not delete target properties not defined on source', ->
+    assign('exists', descriptors.exists, source, target, options)
+    target.should.have.property('exists')
+    target.exists.should.equal 'exists'
 
   it 'should skip private properties by default', ->
     assign('private', descriptors.private, source, target, options)


### PR DESCRIPTION
If a property on incoming data is explicitly set to undefined, Modinha will
delete the matching property off of the model.