### PR TITLE
Use $unset operator for property deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,10 +124,10 @@ Merge works identical to initialize, except that it mutates an existing instance
     var account = new Account({...});
     account.merge(data, { map: 'facebook' });
 
-Explicitly setting a property on an object to undefined will mark that property for deletion. For example,
+If you would like to delete a property off of an object, then set the `$unset` operator on the options object to an array with the list of property names you would like to delete. For example,
 
     var account = new Account({ ssn: '123-456-7890' });
-    account.merge({ ssn: undefined });
+    account.merge({}, { $unset: [ 'ssn' ] });
 
 
 #### Serialization and deserialization

--- a/lib/initialize.js
+++ b/lib/initialize.js
@@ -88,11 +88,6 @@ function assign (key, descriptor, source, target, options) {
       target[key] = value;
     }
 
-    // delete property if explicitly undefined
-    else if (source.hasOwnProperty(key) && value === undefined) {
-      delete target[key];
-    }
-
     // assign default value
     else if (descriptor.default && options.defaults !== false) {
       var defaultValue = descriptor.default;
@@ -100,6 +95,12 @@ function assign (key, descriptor, source, target, options) {
                   ? defaultValue()
                   : defaultValue
                   ;
+    }
+
+    // delete property if explicitly undefined
+    if (Array.isArray(options.$unset) &&
+             options.$unset.indexOf(key) !== -1) {
+      delete target[key];
     }
   }
 

--- a/test/InitializeSpec.coffee
+++ b/test/InitializeSpec.coffee
@@ -74,7 +74,7 @@ describe 'assign', ->
       after:     { type: 'string', after: (data) -> @setAfter = "#{data.after} assignment"}
     source =
       simple: 'simple'
-      deleted: undefined
+      deleted: 'boogers'
       private: 'private'
       immutable: 'immutable'
       setter: 'set'
@@ -82,17 +82,17 @@ describe 'assign', ->
     target =
       deleted: 'not deleted'
       exists:  'exists'
-    options = {}
+    options = { $unset: [ 'deleted' ] }
 
   it 'should set a property on target from source', ->
     assign('simple', descriptors.simple, source, target, options)
     target.simple.should.equal 'simple'
 
-  it 'should remove target properties explicitly undefined on source', ->
+  it 'should remove target properties marked for deletion with $unset', ->
     assign('deleted', descriptors.deleted, source, target, options)
     target.should.not.have.property('deleted')
 
-  it 'should not delete target properties not defined on source', ->
+  it 'should keep target properties not marked for deletion with $unset', ->
     assign('exists', descriptors.exists, source, target, options)
     target.should.have.property('exists')
     target.exists.should.equal 'exists'


### PR DESCRIPTION
After a discussion with @christiansmith, we decided it would be best to make deletion of properties in Modinha more explicit to avoid accidental data deletion, and to make Modinha more intuitive to use.